### PR TITLE
fix: Different pipelines for managed identity and client secret

### DIFF
--- a/azure-pipelines-federated.yaml
+++ b/azure-pipelines-federated.yaml
@@ -80,18 +80,17 @@ stages:
                 printf "%s\n" '$(LE_PRIVATE_KEY_JSON)' > private_key.json
                 printf "%s\n" '$(LE_REGR_JSON)' > regr.json
 
-          - task: PythonScript@0
+          - task: AzureCLI@2
             name: ACMEv2
             condition: and(succeeded(), eq(variables.require_new_certificate, True))
             env:
-              AZURE_TENANT_ID: $(LE_AZURE_TENANT_ID)
               AZURE_SUBSCRIPTION_ID: $(LE_AZURE_SUBSCRIPTION_ID)
-              AZURE_CLIENT_ID: $(LE_AZURE_CLIENT_ID)
-              AZURE_CLIENT_SECRET: $(LE_AZURE_CLIENT_SECRET)
+              AZURE_IDENTITY_TYPE: $(LE_AZURE_IDENTITY_TYPE)
             inputs:
-              scriptSource: filePath
-              scriptPath: acme_tiny.py
-              arguments: --private-key private_key.json --regr regr.json --csr csr.der --out certificate_chain.pem
+              azureSubscription: "$(LE_SERVICE_CONNECTION)"
+              scriptType: bash
+              scriptLocation: inlineScript
+              inlineScript: "python3 acme_tiny.py --private-key private_key.json --regr regr.json --csr csr.der --out certificate_chain.pem"
 
           - task: AzureCLI@2
             name: SaveCertificateInKeyVault


### PR DESCRIPTION
Ensure that legacy pipelines continue to work by using two separate pipeline YAML definitions for legacy pipeline with client secret and new pipelines with managed identity.